### PR TITLE
fix: round number and round time calculations

### DIFF
--- a/chain.js
+++ b/chain.js
@@ -1,0 +1,27 @@
+export default class Chain {
+  /**
+   * roundAt determines the round number given a round time, a chain genesis and
+   * a chain period.
+   *
+   * @param time {number} Round time in ms
+   * @param genesis {number} Chain genesis time in ms
+   * @param period {number} Chain period in ms
+   */
+  static roundAt (time, genesis, period) {
+    if (time < genesis) return 1
+    return Math.floor((time - genesis) / period) + 1
+  }
+
+  /**
+   * roundTime determines the time a round should be available, given a chain
+   * genesis and a chain period.
+   *
+   * @param round {number} Round number
+   * @param genesis {number} Chain genesis time in ms
+   * @param period {number} Chain period in ms
+   */
+  static roundTime (round, genesis, period) {
+    round = round < 0 ? 0 : round
+    return genesis + ((round - 1) * period)
+  }
+}

--- a/chain.test.js
+++ b/chain.test.js
@@ -1,0 +1,26 @@
+import test from 'ava'
+import Chain from './chain.js'
+
+test('should get round 1 when time is less than genesis', t => {
+  t.is(Chain.roundAt(0, 1, 1000), 1)
+})
+
+test('should get round 1 for first round', t => {
+  t.is(Chain.roundAt(1, 0, 1000), 1)
+})
+
+test('should get round 2 for second round', t => {
+  t.is(Chain.roundAt(1001, 0, 1000), 2)
+})
+
+test('should get time 0 when round is < 0', t => {
+  t.is(Chain.roundTime(1, 0, 1000), 0)
+})
+
+test('should get time 0 for first round', t => {
+  t.is(Chain.roundTime(1, 0, 1000), 0)
+})
+
+test('should get time 1000 for second round', t => {
+  t.is(Chain.roundTime(2, 0, 1000), 1000)
+})

--- a/drand.test.js
+++ b/drand.test.js
@@ -6,7 +6,7 @@ import AbortController from 'abort-controller'
 global.fetch = fetch
 global.AbortController = AbortController
 
-const TESTNET_CHAIN_HASH = 'bec303dc34b6d535388773470fa064bdf9aa50e6064fcf02ca96d90ec5cab846'
+const TESTNET_CHAIN_HASH = '5107ecb951646809bf9d56c44168182986e8469aadb906597ede430e24a0408b'
 const TESTNET_URLS = [
   'http://pl-eu.testnet.drand.sh',
   'http://pl-us.testnet.drand.sh',

--- a/http.js
+++ b/http.js
@@ -2,6 +2,7 @@
 
 import { controllerWithParent } from './abort.js'
 import PollingWatcher from './polling-watcher.js'
+import Chain from './chain.js'
 
 export default class HTTP {
   constructor (url, chainInfo, options) {
@@ -55,7 +56,7 @@ export default class HTTP {
   }
 
   roundAt (time) {
-    return Math.floor((time - (this._chainInfo.genesis_time * 1000)) / (this._chainInfo.period * 1000))
+    return Chain.roundAt(time, this._chainInfo.genesis_time * 1000, this._chainInfo.period * 1000)
   }
 
   async close () {

--- a/optimizing.test.js
+++ b/optimizing.test.js
@@ -7,7 +7,7 @@ import AbortController from 'abort-controller'
 global.fetch = fetch
 global.AbortController = AbortController
 
-const TESTNET_CHAIN_HASH = 'bec303dc34b6d535388773470fa064bdf9aa50e6064fcf02ca96d90ec5cab846'
+const TESTNET_CHAIN_HASH = '5107ecb951646809bf9d56c44168182986e8469aadb906597ede430e24a0408b'
 const TESTNET_URLS = [
   'http://pl-eu.testnet.drand.sh',
   'http://pl-us.testnet.drand.sh',

--- a/polling-watcher.js
+++ b/polling-watcher.js
@@ -1,7 +1,8 @@
 import { AbortError, controllerWithParent } from './abort.js'
+import Chain from './chain.js'
 
 async function forNextRound (round, chainInfo, { signal }) {
-  const time = (chainInfo.genesis_time * 1000) + ((round + 1) * (chainInfo.period * 1000))
+  const time = Chain.roundTime(round + 1, chainInfo.genesis_time * 1000, chainInfo.period * 1000)
   const delta = time - Date.now()
   if (delta <= 0) return
   return new Promise((resolve, reject) => {


### PR DESCRIPTION
These were ported too hastily from Go and mistakes were made 🤦‍♂️. Adds a chain utility class for calculating round number and round time and adds tests to ensure the correct numbers are being calculated.