### PR TITLE
feat: add speed test

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ const client = await Client.wrap([/* ... */], options)
 
 Returns the randomness at `round` or an error. Requesting round = 0 will return randomness for the most recent known round, bounded at minimum to `client.roundAt(Date.now())`.
 
+* `options.noCache: boolean` - bypass the cache.
 * `options.signal: AbortSignal` - a signal obtained from an [AbortController](https://developer.mozilla.org/en-US/docs/Web/API/AbortController) that can be used to abort the request.
 
 e.g.
@@ -141,6 +142,7 @@ const res = await client.get(round)
 
 Info returns the parameters of the chain this client is connected to. The public key, when it started, and how frequently it updates.
 
+* `options.noCache: boolean` - bypass the cache.
 * `options.signal: AbortSignal` - a signal obtained from an [AbortController](https://developer.mozilla.org/en-US/docs/Web/API/AbortController) that can be used to abort the request.
 
 e.g.

--- a/http.js
+++ b/http.js
@@ -25,7 +25,7 @@ export default class HTTP {
     this._controllers.push(controller)
 
     try {
-      const url = `${this._url}/public/${round || 'latest'}`
+      const url = `${this._url}/public/${round || 'latest'}${options.noCache ? '?' + Date.now() : ''}`
       const res = await fetch(url, { signal: controller.signal })
       if (!res.ok) throw new Error(`unexpected HTTP status ${res.status} for URL ${url}`)
       const rand = await res.json()

--- a/http.js
+++ b/http.js
@@ -42,7 +42,7 @@ export default class HTTP {
 
   static async info (url, chainHash, options) {
     options = options || {}
-    const res = await fetch(`${url}/info`, { signal: options.signal })
+    const res = await fetch(`${url}/info${options.noCache ? '?' + Date.now() : ''}`, { signal: options.signal })
     if (!res.ok) throw new Error(`unexpected HTTP status ${res.status} for URL ${url}/info`)
     const info = await res.json()
     if (chainHash && chainHash !== info.hash) {

--- a/mock.js
+++ b/mock.js
@@ -1,0 +1,100 @@
+import Chain from './chain.js'
+import { AbortError, controllerWithParent } from './abort.js'
+
+/**
+ * A mock client for testing.
+ *
+ * @param [options] {object}
+ * @param [options.beacons] {[]object} beacons to use in watch and get note that
+ * only using watch will progress the latest beacon. Each beacon object in the
+ * array can optionally have a `delay` property which will cause it to be
+ * delayed before being returned/yielded by get/watch.
+ * @param [options.latestBeaconIndex] {number} Index in `options.beacon` of the
+ * latest beacon.
+ * @param [options.chainInfo] {object} The chain info
+ */
+export default class Mock {
+  constructor (options) {
+    this._options = options || {}
+    this._beaconIndex = 0 || this._options.latestBeaconIndex
+    this._controllers = []
+  }
+
+  async get (round, options) {
+    options = options || {}
+    const beacons = this._options.beacons || []
+    const beacon = round
+      ? beacons.find(b => b.round === round)
+      : beacons[this._beaconIndex]
+    if (!beacon) throw new Error('not found')
+
+    const controller = controllerWithParent(options.signal)
+    this._controllers.push(controller)
+
+    try {
+      await waitOrAbort(beacon.delay || 0, controller.signal)
+    } finally {
+      this._controllers = this._controllers.filter(c => c !== controller)
+      controller.abort()
+    }
+
+    return beacon
+  }
+
+  info () {
+    const { chainInfo } = this._options
+    if (!chainInfo) throw new Error('no chain info passed to constructor')
+    return chainInfo
+  }
+
+  async * watch (options) {
+    options = options || {}
+    const { chainInfo } = this._options
+    if (!chainInfo) throw new Error('watch needs to know period from missing chain info')
+
+    const controller = controllerWithParent(options.signal)
+    this._controllers.push(controller)
+
+    const beacons = this._options.beacons || []
+
+    try {
+      while (true) {
+        const beacon = beacons[this._beaconIndex]
+        if (!beacon) throw new Error(`no beacon at index ${this._beaconIndex}`)
+        await waitOrAbort(beacon.delay || 0, controller.signal)
+        yield beacon
+        this._beaconIndex++
+        await waitOrAbort(chainInfo.period * 1000, controller.signal)
+      }
+    } finally {
+      this._controllers = this._controllers.filter(c => c !== controller)
+      controller.abort()
+    }
+  }
+
+  roundAt (time) {
+    const { chainInfo } = this._options
+    if (!chainInfo) throw new Error('roundAt needs genesis and period from missing chain info')
+    return Chain.roundAt(time, chainInfo.genesis_time * 1000, chainInfo.period * 1000)
+  }
+
+  close () {
+    this._controllers.forEach(c => c.abort())
+    this._controllers = []
+  }
+}
+
+function waitOrAbort (duration, signal) {
+  return new Promise((resolve, reject) => {
+    if (signal.aborted) return reject(new AbortError())
+    const timeoutID = setTimeout(() => {
+      signal.removeEventListener('abort', onAbort)
+      resolve()
+    }, duration)
+    const onAbort = () => {
+      clearTimeout(timeoutID)
+      reject(new AbortError())
+    }
+    signal.addEventListener('abort', onAbort)
+  })
+}

--- a/optimizing.js
+++ b/optimizing.js
@@ -1,31 +1,95 @@
+/* eslint-env browser */
+
+const SPEED_TEST_INTERVAL = 1000 * 30
+
 export default class Optimizing {
-  // TODO: options with default request timeout, concurrency and speed test interval
-  constructor (clients) {
+  // TODO: options for default request timeout and concurrency
+  constructor (clients, options) {
     this._clients = clients
-    // TODO: periodic speed test for clients
+    this._stats = clients.map(c => ({ client: c, rtt: 0, startTime: Date.now() }))
+    this._options = options || {}
+    this._options.speedTestInterval = this._options.speedTestInterval || SPEED_TEST_INTERVAL
   }
 
-  async start () {
-    // TODO: start speed test
+  start () {
+    if (this._options.speedTestInterval > 0) {
+      return this._testSpeed()
+    }
+  }
+
+  _testSpeed () {
+    const run = async () => {
+      const stats = await Promise.all(this._clients.map(async c => {
+        try {
+          const res = await this._get(c, 1)
+          return res.stat
+        } catch (_) {
+          // An abort happened
+        }
+      }))
+      this._updateStats(stats.filter(Boolean))
+    }
+    this._speedTestIntervalID = setInterval(run, this._options.speedTestInterval)
+    return run()
+  }
+
+  _fastestClients () {
+    return this._stats.map(s => s.client)
+  }
+
+  _updateStats (stats) {
+    for (const next of stats) {
+      for (const curr of this._stats) {
+        if (curr.client === next.client) {
+          if (curr.startTime < next.startTime) {
+            curr.rtt = next.rtt
+            curr.startTime = next.startTime
+          }
+          break
+        }
+      }
+    }
+    this._stats.sort((a, b) => a.rtt - b.rtt)
   }
 
   async get (round, options) {
-    // TODO: race with concurrency
-    for (const client of this._clients) {
-      try {
-        const rand = await client.get(round, options)
-        return rand
-      } catch (err) {
-        if (client === this._clients[this._clients.length - 1]) {
-          throw err
+    const stats = []
+    try {
+      let res
+      // TODO: race with concurrency
+      for (const client of this._fastestClients()) {
+        res = await this._get(client, round, options)
+        stats.push(res.stat)
+        if (!res.error) {
+          return res.rand
         }
       }
+      throw res.error
+    } finally {
+      this._updateStats(stats)
+    }
+  }
+
+  // _get performs get on the passed client, recording a request stat. If an
+  // error occurs that is not an abort error then a result will still be
+  // returned with an error property.
+  async _get (client, round, options) {
+    const startTime = Date.now()
+    try {
+      const rand = await client.get(round, options)
+      return { rand, stat: { client, rtt: Date.now() - startTime, startTime } }
+    } catch (err) {
+      // client failure, set a large RTT so it is sent to the back of the list
+      if (err.name !== 'AbortError') {
+        return { error: err, stat: { client, rtt: Number.MAX_SAFE_INTEGER, startTime } }
+      }
+      throw err
     }
   }
 
   async * watch (options) {
     // TODO: watch and race all clients
-    const client = this._clients[Math.floor(Math.random() * this._clients.length)]
+    const client = this._fastestClients()[0]
     yield * client.watch(options)
   }
 
@@ -47,6 +111,7 @@ export default class Optimizing {
   }
 
   async close () {
+    clearInterval(this._speedTestIntervalID)
     return Promise.all(this._clients.map(c => c.close()))
   }
 }

--- a/optimizing.js
+++ b/optimizing.js
@@ -1,6 +1,6 @@
 /* eslint-env browser */
 
-const SPEED_TEST_INTERVAL = 1000 * 30
+const SPEED_TEST_INTERVAL = 1000 * 60 * 5
 
 export default class Optimizing {
   // TODO: options for default request timeout and concurrency

--- a/optimizing.js
+++ b/optimizing.js
@@ -21,7 +21,7 @@ export default class Optimizing {
     const run = async () => {
       const stats = await Promise.all(this._clients.map(async c => {
         try {
-          const res = await this._get(c, 1)
+          const res = await this._get(c, 1, { noCache: true })
           return res.stat
         } catch (_) {
           // An abort happened

--- a/optimizing.js
+++ b/optimizing.js
@@ -41,7 +41,7 @@ export default class Optimizing {
     for (const next of stats) {
       for (const curr of this._stats) {
         if (curr.client === next.client) {
-          if (curr.startTime < next.startTime) {
+          if (curr.startTime <= next.startTime) {
             curr.rtt = next.rtt
             curr.startTime = next.startTime
           }

--- a/optimizing.test.js
+++ b/optimizing.test.js
@@ -3,6 +3,7 @@ import HTTP from './http.js'
 import Optimizing from './optimizing.js'
 import fetch from 'node-fetch'
 import AbortController from 'abort-controller'
+import Mock from './mock.js'
 
 global.fetch = fetch
 global.AbortController = AbortController
@@ -68,4 +69,89 @@ test('should fail to get info if all clients fail', async t => {
   const err = await t.throwsAsync(client.info())
   t.is(err.message, 'boom')
   t.is(calls, 2)
+})
+
+test('should get from the fastest client', async t => {
+  const fastBeacons = [{ round: 138 }, { round: 139 }, { round: 140 }]
+  const fast = new Mock({ beacons: [{ round: 1 }, ...fastBeacons] })
+  // This client shouldn't be used other than for the speed test
+  class Slow extends Mock {
+    get (round, options) {
+      if (round !== 1) t.fail(`not expected to call get other than for speed test (${round})`)
+      return super.get(round, options)
+    }
+  }
+  const slow = new Slow({ beacons: [{ round: 1, delay: 100 }] })
+
+  const client = new Optimizing([slow, fast])
+  await client.start()
+
+  for (const beacon of fastBeacons) {
+    const b = await client.get(beacon.round)
+    t.is(b.round, beacon.round)
+  }
+
+  await client.close()
+})
+
+test('should watch from the fastest client', async t => {
+  const chainInfo = { period: 1 }
+
+  const fastBeacons = [{ round: 138 }, { round: 139 }, { round: 140 }]
+  const fast = new Mock({
+    beacons: [{ round: 1 }, ...fastBeacons],
+    latestBeaconIndex: 1,
+    chainInfo
+  })
+  // This client shouldn't be used other than for the speed test
+  class Slow extends Mock {
+    watch () {
+      t.fail('not expected to call watch')
+    }
+  }
+  const slow = new Slow({ beacons: [{ round: 1, delay: 100 }] })
+
+  const client = new Optimizing([slow, fast])
+  await client.start()
+
+  const watchedBeacons = client.watch()
+
+  for (const beacon of fastBeacons) {
+    const b = (await watchedBeacons.next()).value
+    t.is(b.round, beacon.round)
+  }
+
+  watchedBeacons.return()
+  await client.close()
+})
+
+test('should switch to a faster client', async t => {
+  const beacons = [{ round: 138 }, { round: 139 }, { round: 140 }]
+
+  class FastThenSlow extends Mock {
+    get (round, options) {
+      if (round > 139) t.fail(`not expected to be asked for beacons > 139 (${round})`)
+      return super.get(round, options)
+    }
+  }
+  const fastThenSlow = new FastThenSlow({
+    beacons: [{ round: 1 }, ...[beacons[0], ...beacons.slice(1).map(b => ({ ...b, delay: 200 }))]]
+  })
+  class Steady extends Mock {
+    get (round, options) {
+      if (round > 1 && round < 140) t.fail(`not expected to be asked for beacons < 140 (${round})`)
+      return super.get(round, options)
+    }
+  }
+  const steady = new Steady({ beacons: [{ round: 1, delay: 100 }, ...beacons.map(b => ({ ...b, delay: 100 }))] })
+
+  const client = new Optimizing([fastThenSlow, steady])
+  await client.start()
+
+  for (const beacon of beacons) {
+    const b = await client.get(beacon.round)
+    t.is(b.round, beacon.round)
+  }
+
+  await client.close()
 })

--- a/polling-watcher.js
+++ b/polling-watcher.js
@@ -6,6 +6,7 @@ async function forNextRound (round, chainInfo, { signal }) {
   const delta = time - Date.now()
   if (delta <= 0) return
   return new Promise((resolve, reject) => {
+    if (signal.aborted) return reject(new AbortError())
     const timeoutID = setTimeout(() => {
       signal.removeEventListener('abort', onAbort)
       resolve()


### PR DESCRIPTION
A port of the speed test from [optimizing.go](https://github.com/drand/drand/blob/master/client/optimizing.go) with 5 min interval. Note, this PR does not implement the watch client cycling from https://github.com/drand/drand/pull/629.

TODO: 

* [x] add tests

resolves https://github.com/drand/drand-client/issues/2