### PR TITLE
Fix the `roundTime` method (broken after typescript migration)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,9 +22,8 @@ jobs:
 
       - name: publish to npmjs
         uses: JS-DevTools/npm-publish@v1
+        if: github.ref == 'refs/heads/master'
         with:
           token: ${{ secrets.NPM_TOKEN }}
-          # dry run if on a side branch
-          dry-run: ${{ github.ref != 'refs/heads/master' }}
           # don't try and deploy if versions haven't changed
           check-version: true

--- a/lib/chain.ts
+++ b/lib/chain.ts
@@ -15,7 +15,7 @@ export default class Chain {
 
 
     /**
-     * roundTime determines the time a round should be available, given a chain
+     * roundTime determines the time a round should be available (in milliseconds), given a chain
      * genesis and a chain period.
      *
      * @param round {number} Round number
@@ -24,6 +24,6 @@ export default class Chain {
      */
     static roundTime (round: number, genesis: number, period: number) {
         round = round < 0 ? 0 : round
-        return genesis + ((round - 1) * period) * 1000
+        return (genesis + (round - 1) * period) * 1000
     }
 }

--- a/test/chain.test.ts
+++ b/test/chain.test.ts
@@ -23,3 +23,19 @@ test('should get time 0 for first round', () => {
 test('should get time 1000 for second round', () => {
   expect(Chain.roundTime(2, 0, 1)).toBe(1000)
 })
+
+test('should get time of genesis (in ms) for first round', () => {
+  expect(Chain.roundTime(1, 1595431050, 1)).toBe(1595431050000)
+})
+
+test('should get time genesis + 1000 for second round', () => {
+  expect(Chain.roundTime(2, 1595431050, 1)).toBe(1595431051000)
+})
+
+test('should work with different period as well', () => {
+  expect(Chain.roundTime(2, 1595431050, 30)).toBe(1595431080000)
+})
+
+test('and should work with a larger round number', () => {
+  expect(Chain.roundTime(2185561, 1595431050, 30)).toBe(1660997850000)
+})

--- a/test/drand.test.ts
+++ b/test/drand.test.ts
@@ -55,7 +55,7 @@ test('should watch for randomness', async () => {
         {chainHash: TESTNET_CHAIN_HASH}
     )
     
-    let startTime = Date.now();
+    const startTime = Date.now();
     try {
         let i = 0
         for await(const rand of drand.watch({signal: new AbortController().signal})) {

--- a/test/drand.test.ts
+++ b/test/drand.test.ts
@@ -54,7 +54,8 @@ test('should watch for randomness', async () => {
         await HTTP.forURLs(TESTNET_URLS, TESTNET_CHAIN_HASH),
         {chainHash: TESTNET_CHAIN_HASH}
     )
-
+    
+    let startTime = Date.now();
     try {
         let i = 0
         for await(const rand of drand.watch({signal: new AbortController().signal})) {
@@ -72,6 +73,9 @@ test('should watch for randomness', async () => {
             throw err
         }
     }
+    // check to make sure the watch did not exit too soon
+    // it should take no less than 30s, so we'll use 25s to be safe
+    expect(Date.now() - startTime).toBeGreaterThan(25000)
     // if we get unlucky and start just after a beacon is release we may need to wait some time for the next one
     // by default, the testnet beacons are every 30secs
 }, 65000)


### PR DESCRIPTION
During the typescript migration, the [`roundTime` method](https://github.com/drand/drand-client/blob/bdfdb7a64c52862f7b6353b851bddd9f1b589e7f/lib/chain.ts#L25) was changed from this:

```js
/**
   * roundTime determines the time a round should be available, given a chain
   * genesis and a chain period.
   *
   * @param round {number} Round number
   * @param genesis {number} Chain genesis time in ms
   * @param period {number} Chain period in ms
   */
  static roundTime (round, genesis, period) {
    round = round < 0 ? 0 : round
    return genesis + ((round - 1) * period)
  }
```
to this:
```ts
/**
     * roundTime determines the time a round should be available, given a chain
     * genesis and a chain period.
     *
     * @param round {number} Round number
     * @param genesis {number} Chain genesis time in seconds
     * @param period {number} Chain period in seconds
     */
    static roundTime (round: number, genesis: number, period: number) {
        round = round < 0 ? 0 : round
        return genesis + ((round - 1) * period) * 1000
    }
}
```

As the method now receives times in seconds, the result should be multiplied by 1000, but the genesis was not included in this multiplication. As such, the returned value is far too low.

The tests for `chain.ts` did not catch this as they all used a genesis of 0.

This bug also breaks `Client.watch` as the value passed to `waitOrAbort` is negative, thus making it repeatedly get the same round. I've changed `drand.test.ts` to make the watch test check if it finished too early.

This PR fixes the `roundTime` method by moving the parentheses, adds extra tests for `roundTime`, and modifies one test in `drand.test.ts`.