### PR TITLE
Only run publish to npmjs on master

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,9 +22,8 @@ jobs:
 
       - name: publish to npmjs
         uses: JS-DevTools/npm-publish@v1
+        if: github.ref == 'refs/heads/master'
         with:
           token: ${{ secrets.NPM_TOKEN }}
-          # dry run if on a side branch
-          dry-run: ${{ github.ref != 'refs/heads/master' }}
           # don't try and deploy if versions haven't changed
           check-version: true


### PR DESCRIPTION
* changed dry run on side branches to skipping entirely as
  non-maintainers can't use the NPM_TOKEN secret and the run just fails