### PR TITLE
propagate a default user agent everywhere

### DIFF
--- a/lib/http-chain-client.ts
+++ b/lib/http-chain-client.ts
@@ -1,19 +1,22 @@
 import {Chain, ChainClient, ChainOptions, defaultChainOptions, RandomnessBeacon} from './index'
-import {jsonOrError} from './util'
+import {defaultHttpOptions, HttpOptions, jsonOrError} from './util'
 
 class HttpChainClient implements ChainClient {
 
-    constructor(private someChain: Chain, public options: ChainOptions = defaultChainOptions) {
+    constructor(
+        private someChain: Chain,
+        public options: ChainOptions = defaultChainOptions,
+        public httpOptions: HttpOptions = defaultHttpOptions) {
     }
 
     async get(roundNumber: number): Promise<RandomnessBeacon> {
         const url = withCachingParams(`${this.someChain.baseUrl}/public/${roundNumber}`, this.options)
-        return await jsonOrError(url)
+        return await jsonOrError(url, this.httpOptions)
     }
 
     async latest(): Promise<RandomnessBeacon> {
         const url = withCachingParams(`${this.someChain.baseUrl}/public/latest`, this.options)
-        return await jsonOrError(url)
+        return await jsonOrError(url, this.httpOptions)
     }
 
     chain(): Chain {

--- a/lib/util.ts
+++ b/lib/util.ts
@@ -1,4 +1,5 @@
 import {ChainInfo} from './index'
+import {version} from '../package.json'
 
 export function sleep(timeMs: number): Promise<void> {
     return new Promise(resolve => {
@@ -25,8 +26,12 @@ export type HttpOptions = {
     userAgent?: string
 }
 
+export const defaultHttpOptions: HttpOptions = {
+    userAgent: `drand-client-${version}`
+}
+
 // eslint-disable-next-line  @typescript-eslint/no-explicit-any
-export async function jsonOrError(url: string, options: HttpOptions = {}): Promise<any> {
+export async function jsonOrError(url: string, options: HttpOptions = defaultHttpOptions): Promise<any> {
     let requestOptions = {}
 
     if (options.userAgent) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "drand-client",
-  "version": "1.0.0-pre.7",
+  "version": "1.0.0-pre.8",
   "description": "A client to the drand randomness beacon network.",
   "main": "index.js",
   "types": "index.d.ts",

--- a/test/http-chain-client.test.ts
+++ b/test/http-chain-client.test.ts
@@ -1,7 +1,7 @@
 import fetchMock from 'jest-fetch-mock'
 import {HttpChainClient} from '../lib'
 import {testChain, validTestBeacon} from './data'
-import {defaultHttpOptions} from "../lib/util";
+import {defaultHttpOptions} from '../lib/util'
 
 beforeAll(() => {
     fetchMock.enableMocks()
@@ -44,18 +44,18 @@ describe('http chain client', () => {
 
         it('should pass the custom user agent to fetch', async () => {
             const roundNumber = 1
-            const customUserAgent = "bananasinpyjamas"
+            const customUserAgent = 'bananasinpyjamas'
             const client = new HttpChainClient(testChain, {
                 noCache: false,
                 disableBeaconVerification: false
             }, {userAgent: customUserAgent})
 
-            fetchMock.mockIf(req => req.headers.get("User-Agent") == customUserAgent, JSON.stringify(validTestBeacon))
+            fetchMock.mockIf(req => req.headers.get('User-Agent') == customUserAgent, JSON.stringify(validTestBeacon))
             await expect(client.get(roundNumber)).resolves.toEqual(validTestBeacon)
             expect(fetchMock).toHaveBeenCalledTimes(1)
             expect(fetchMock).toHaveBeenCalledWith(`https://example.com/public/${roundNumber}`, {
-                "headers": {
-                    "User-Agent": customUserAgent
+                'headers': {
+                    'User-Agent': customUserAgent
                 }
             })
         })
@@ -81,18 +81,18 @@ describe('http chain client', () => {
         })
 
         it('should pass the custom user agent to fetch', async () => {
-            const customUserAgent = "bananasinpyjamas"
+            const customUserAgent = 'bananasinpyjamas'
             const client = new HttpChainClient(testChain, {
                 noCache: false,
                 disableBeaconVerification: false
             }, {userAgent: customUserAgent})
 
-            fetchMock.mockIf(req => req.headers.get("User-Agent") == customUserAgent, JSON.stringify(validTestBeacon))
+            fetchMock.mockIf(req => req.headers.get('User-Agent') == customUserAgent, JSON.stringify(validTestBeacon))
             await expect(client.latest()).resolves.toEqual(validTestBeacon)
             expect(fetchMock).toHaveBeenCalledTimes(1)
-            expect(fetchMock).toHaveBeenCalledWith(`https://example.com/public/latest`, {
-                "headers": {
-                    "User-Agent": customUserAgent
+            expect(fetchMock).toHaveBeenCalledWith('https://example.com/public/latest', {
+                'headers': {
+                    'User-Agent': customUserAgent
                 }
             })
         })

--- a/test/http-chain-client.test.ts
+++ b/test/http-chain-client.test.ts
@@ -1,6 +1,7 @@
 import fetchMock from 'jest-fetch-mock'
 import {HttpChainClient} from '../lib'
 import {testChain, validTestBeacon} from './data'
+import {defaultHttpOptions} from "../lib/util";
 
 beforeAll(() => {
     fetchMock.enableMocks()
@@ -14,6 +15,11 @@ beforeEach(() => {
 
 describe('http chain client', () => {
     const client = new HttpChainClient(testChain)
+    const defaultFetchOptions = {
+        headers: {
+            'User-Agent': defaultHttpOptions.userAgent
+        }
+    }
 
     describe('get', () => {
         it('should call the API with the provided round number', async () => {
@@ -22,7 +28,7 @@ describe('http chain client', () => {
 
             await expect(client.get(roundNumber)).resolves.toEqual(validTestBeacon)
             expect(fetchMock).toHaveBeenCalledTimes(1)
-            expect(fetchMock).toHaveBeenCalledWith(`https://example.com/public/${roundNumber}`, {})
+            expect(fetchMock).toHaveBeenCalledWith(`https://example.com/public/${roundNumber}`, defaultFetchOptions)
         })
 
         it('should call with API with a query param if noCache is set', async () => {
@@ -33,7 +39,25 @@ describe('http chain client', () => {
             await expect(client.get(roundNumber)).resolves.toEqual(validTestBeacon)
 
             // should have been with cache busting params, not just the normal latest endpoint
-            expect(fetchMock).not.toHaveBeenCalledWith(`https://example.com/public/${roundNumber}`, {})
+            expect(fetchMock).not.toHaveBeenCalledWith(`https://example.com/public/${roundNumber}`, defaultFetchOptions)
+        })
+
+        it('should pass the custom user agent to fetch', async () => {
+            const roundNumber = 1
+            const customUserAgent = "bananasinpyjamas"
+            const client = new HttpChainClient(testChain, {
+                noCache: false,
+                disableBeaconVerification: false
+            }, {userAgent: customUserAgent})
+
+            fetchMock.mockIf(req => req.headers.get("User-Agent") == customUserAgent, JSON.stringify(validTestBeacon))
+            await expect(client.get(roundNumber)).resolves.toEqual(validTestBeacon)
+            expect(fetchMock).toHaveBeenCalledTimes(1)
+            expect(fetchMock).toHaveBeenCalledWith(`https://example.com/public/${roundNumber}`, {
+                "headers": {
+                    "User-Agent": customUserAgent
+                }
+            })
         })
     })
 
@@ -43,7 +67,7 @@ describe('http chain client', () => {
 
             await expect(client.latest()).resolves.toEqual(validTestBeacon)
             expect(fetchMock).toHaveBeenCalledTimes(1)
-            expect(fetchMock).toHaveBeenCalledWith('https://example.com/public/latest', {})
+            expect(fetchMock).toHaveBeenCalledWith('https://example.com/public/latest', defaultFetchOptions)
         })
 
         it('should call with API with a query param if noCache is set', async () => {
@@ -53,7 +77,24 @@ describe('http chain client', () => {
             await expect(client.latest()).resolves.toEqual(validTestBeacon)
 
             // should have been with random cache busting params, not just the normal `/latest` endpoint
-            expect(fetchMock).not.toHaveBeenCalledWith('https://example.com/public/latest', {})
+            expect(fetchMock).not.toHaveBeenCalledWith('https://example.com/public/latest', defaultFetchOptions)
+        })
+
+        it('should pass the custom user agent to fetch', async () => {
+            const customUserAgent = "bananasinpyjamas"
+            const client = new HttpChainClient(testChain, {
+                noCache: false,
+                disableBeaconVerification: false
+            }, {userAgent: customUserAgent})
+
+            fetchMock.mockIf(req => req.headers.get("User-Agent") == customUserAgent, JSON.stringify(validTestBeacon))
+            await expect(client.latest()).resolves.toEqual(validTestBeacon)
+            expect(fetchMock).toHaveBeenCalledTimes(1)
+            expect(fetchMock).toHaveBeenCalledWith(`https://example.com/public/latest`, {
+                "headers": {
+                    "User-Agent": customUserAgent
+                }
+            })
         })
     })
 })

--- a/test/util.test.ts
+++ b/test/util.test.ts
@@ -94,7 +94,7 @@ describe('jsonOrError', () => {
         expect(response).toEqual(expectedResponse)
         expect(fetchMock).toHaveBeenCalledTimes(1)
     })
-    it('should leave user agent empty if not passed', async () => {
+    it('should not use default user agent empty if empty', async () => {
         const expectedUrl = 'https://example.com/'
         const expectedResponse = { great: true }
 
@@ -106,7 +106,7 @@ describe('jsonOrError', () => {
             return new Promise(resolve => resolve(JSON.stringify(expectedResponse)))
         })
 
-        const response = await jsonOrError(expectedUrl)
+        const response = await jsonOrError(expectedUrl, { userAgent: ''})
 
         expect(response).toEqual(expectedResponse)
         expect(fetchMock).toHaveBeenCalledTimes(1)


### PR DESCRIPTION
enable use of a custom user agent with the HttpChainClient and not just HttpChain