### PR TITLE
Update GitHub Actions to use Node.js 22.x

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: 19.4.0
+          node-version: 22.x
 
       - name: Bump version and push tag
         id: tag_version

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,6 +1,7 @@
 module.exports = {
   preset: "ts-jest",
   testEnvironment: 'node',
+  testTimeout: 30000,
   transform: {
     '^.+\\.ts?$': 'ts-jest',
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "drand-client",
-  "version": "1.2.3",
+  "version": "1.2.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "drand-client",
-      "version": "1.2.3",
+      "version": "1.2.6",
       "license": "(Apache-2.0 OR MIT)",
       "dependencies": {
         "@babel/traverse": "^7.23.2",


### PR DESCRIPTION
### **Title:**  
Update GitHub Actions to use Node.js 22.x  

### **Description:**  
This PR updates the GitHub Actions workflow to use Node.js version 22.x for running tests.  

- The change was made to verify compatibility with the latest LTS version of Node.js.  
- Locally, all tests passed successfully after updating the `testTimeout` value in `jest.config.ts`.  
- This PR will confirm if the CI pipeline also runs successfully with these updates.  

### **Changes Made:**  
1. Updated `node-version` in the GitHub Actions workflow file to `22.x`.  
2. Tested compatibility with the newer Node.js version locally.  

### **Testing:**  
- Local tests were successful with Node.js 22.13.0 after updating the Jest configuration.  
- This PR will trigger the CI pipeline to verify the results.  

### **Related Issue:**  
Resolves #79 