### PR TITLE
give actions more permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   build_test_and_publish:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
seems like I can't run the other contributor's action without it: https://github.com/drand/drand-client/actions/runs/13178909916/job/36989349094?pr=90